### PR TITLE
Add SwiftUI starter for Bleep clone

### DIFF
--- a/BleepClone/App/BleepCloneApp.swift
+++ b/BleepClone/App/BleepCloneApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import SwiftData
+
+@main
+struct BleepCloneApp: App {
+    var body: some Scene {
+        WindowGroup {
+            HomeView()
+        }
+        .modelContainer(for: [Room.self, Item.self])
+    }
+}

--- a/BleepClone/Models/Models.swift
+++ b/BleepClone/Models/Models.swift
@@ -1,0 +1,79 @@
+import SwiftData
+import Foundation
+
+@Model
+final class Room {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var icon: RoomIcon
+    var createdAt: Date
+    var archived: Bool
+    @Relationship(deleteRule: .cascade) var items: [Item]
+    @Relationship(inverse: \Room.parent) var children: [Room]
+    var parent: Room?
+
+    init(name: String, icon: RoomIcon = .none, parent: Room? = nil) {
+        self.id = UUID()
+        self.name = name
+        self.icon = icon
+        self.createdAt = .now
+        self.archived = false
+        self.items = []
+        self.children = []
+        self.parent = parent
+    }
+}
+
+enum RoomIcon: Codable {
+    case none
+    case emoji(String)
+    case imageFile(String)
+}
+
+enum ItemKind: Codable {
+    case note
+    case link
+    case image
+}
+
+@Model
+final class Item {
+    @Attribute(.unique) var id: UUID
+    var kind: ItemKind
+    var title: String
+    var subtitle: String?
+    var room: Room?
+    var createdAt: Date
+    var updatedAt: Date
+    var archived: Bool
+    var note: NotePayload?
+    var link: LinkPayload?
+    var image: ImagePayload?
+
+    init(kind: ItemKind, title: String, subtitle: String? = nil, room: Room?) {
+        self.id = UUID()
+        self.kind = kind
+        self.title = title
+        self.subtitle = subtitle
+        self.room = room
+        self.createdAt = .now
+        self.updatedAt = .now
+        self.archived = false
+    }
+}
+
+struct NotePayload: Codable {
+    var markdown: String
+}
+
+struct LinkPayload: Codable {
+    var url: URL
+    var domain: String
+    var summary: String?
+    var imageFile: String?
+}
+
+struct ImagePayload: Codable {
+    var imageFile: String
+    var caption: String?
+}

--- a/BleepClone/README.md
+++ b/BleepClone/README.md
@@ -1,0 +1,16 @@
+# Bleep Clone – SwiftUI Starter
+
+This project scaffolds an iOS 17 SwiftUI application that mirrors the "Bleep" personal knowledge collector showcased in the design references. It includes models, services, UI components, and seed data to deliver rooms, card-based items, search, and detail views for notes, links, and images.
+
+## Structure
+
+```
+BleepClone/
+  App/
+  Models/
+  Services/
+  Stores/
+  UI/
+```
+
+Refer to the inline documentation for implementation specifics and extend the placeholders (e.g., presenting sheets for adding links/images) to complete the experience.

--- a/BleepClone/Services/ImageStore.swift
+++ b/BleepClone/Services/ImageStore.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+actor ImageStore {
+    static let shared = ImageStore()
+
+    private let directory: URL = {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let directory = base.appending(path: "Images", directoryHint: .isDirectory)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }()
+
+    func save(data: Data, ext: String) throws -> String {
+        let url = directory.appending(path: UUID().uuidString + "." + ext)
+        try data.write(to: url)
+        return url.path
+    }
+}

--- a/BleepClone/Services/LinkPreviewService.swift
+++ b/BleepClone/Services/LinkPreviewService.swift
@@ -1,0 +1,73 @@
+import Foundation
+import LinkPresentation
+import UIKit
+
+actor LinkPreviewService {
+    static let shared = LinkPreviewService()
+
+    func fetch(for url: URL) async throws -> (title: String, domain: String, summary: String?, imagePath: String?) {
+        if let meta = try? await lpMetadata(for: url) {
+            let title = meta.title ?? url.absoluteString
+            let domain = url.host() ?? ""
+            let summary = meta.value(forKey: "_summary") as? String
+            let imagePath = await saveImage(from: meta)
+            return (title, domain, summary, imagePath)
+        }
+
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let html = String(decoding: data, as: UTF8.self)
+        let title = match(html, pattern: "<meta property=\"og:title\" content=\"(.*?)\">") ?? url.absoluteString
+        let domain = url.host() ?? ""
+        let desc = match(html, pattern: "<meta property=\"og:description\" content=\"(.*?)\">")
+        var imagePath: String?
+        if let imageURLString = match(html, pattern: "<meta property=\"og:image\" content=\"(.*?)\">")
+            , let imageURL = URL(string: imageURLString) {
+            let (imageData, _) = try await URLSession.shared.data(from: imageURL)
+            imagePath = try await ImageStore.shared.save(data: imageData, ext: "jpg")
+        }
+        return (title, domain, desc, imagePath)
+    }
+
+    private func lpMetadata(for url: URL) async throws -> LPLinkMetadata? {
+        try await withCheckedThrowingContinuation { continuation in
+            let provider = LPMetadataProvider()
+            provider.startFetchingMetadata(for: url) { metadata, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: metadata)
+                }
+            }
+        }
+    }
+
+    private func match(_ html: String, pattern: String) -> String? {
+        guard let regex = try? NSRegularExpression(
+            pattern: pattern,
+            options: [.dotMatchesLineSeparators, .caseInsensitive]
+        ) else {
+            return nil
+        }
+        let range = NSRange(location: 0, length: html.utf16.count)
+        guard let match = regex.firstMatch(in: html, options: [], range: range), match.numberOfRanges > 1,
+              let valueRange = Range(match.range(at: 1), in: html) else {
+            return nil
+        }
+        return String(html[valueRange])
+    }
+
+    private func saveImage(from metadata: LPLinkMetadata) async -> String? {
+        guard let provider = metadata.imageProvider else {
+            return nil
+        }
+        do {
+            let image = try await provider.loadObject(ofClass: UIImage.self) as! UIImage
+            guard let data = image.jpegData(compressionQuality: 0.9) else {
+                return nil
+            }
+            return try await ImageStore.shared.save(data: data, ext: "jpg")
+        } catch {
+            return nil
+        }
+    }
+}

--- a/BleepClone/Stores/RoomStore.swift
+++ b/BleepClone/Stores/RoomStore.swift
@@ -1,0 +1,26 @@
+import SwiftData
+
+struct RoomSeeder {
+    static func seedIfNeeded(modelContext: ModelContext) {
+        let descriptor = FetchDescriptor<Room>()
+        if let count = try? modelContext.fetchCount(descriptor), count == 0 {
+            let inspiration = Room(name: "Inspiration")
+            let journal = Room(name: "Journal")
+            modelContext.insert(inspiration)
+            modelContext.insert(journal)
+
+            let note = Item(kind: .note, title: "Hi 👋", room: inspiration)
+            note.note = .init(markdown: """
+            # Hi 👋
+            This is a note. In Bleep, you have flexibility to write detailed thoughts, but also save articles, movies to watch (or any bookmark really) as well as images that you can collect and curate.
+
+            ## Get Started
+            - Read this note, or at least skim it!
+            - Save a link: maybe a TV show you want to watch?
+            - Take a picture and save it here
+            - Write a list of things you got done this week
+            """)
+            modelContext.insert(note)
+        }
+    }
+}

--- a/BleepClone/UI/Components/ActionBar.swift
+++ b/BleepClone/UI/Components/ActionBar.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct ActionBar: View {
+    var onNewNote: () -> Void
+    var onAddLink: () -> Void
+    var onAddImage: () -> Void
+
+    var body: some View {
+        HStack(spacing: 28) {
+            Button(action: onNewNote) { Image(systemName: "square.and.pencil") }
+            Button(action: onAddLink) { Image(systemName: "link.badge.plus") }
+            Button(action: onAddImage) { Image(systemName: "photo.on.rectangle") }
+        }
+        .font(.title2)
+        .padding(.horizontal, 26)
+        .padding(.vertical, 12)
+        .background(.ultraThinMaterial, in: Capsule())
+        .shadow(radius: 6, y: 2)
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/BleepClone/UI/Components/CardView.swift
+++ b/BleepClone/UI/Components/CardView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct CardView: View {
+    let item: Item
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            thumbnail
+                .frame(height: 120)
+                .frame(maxWidth: .infinity)
+                .clipped()
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+
+            Text(item.title)
+                .font(.headline)
+                .lineLimit(2)
+
+            if let subtitle = item.subtitle, !subtitle.isEmpty {
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if let roomName = item.room?.name {
+                Text(roomName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 22))
+        .contextMenu { ItemContextMenu(item: item) }
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        switch item.kind {
+        case .note:
+            ZStack(alignment: .topLeading) {
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.gray.opacity(0.15))
+                Text(item.note?.markdown.prefix(120) ?? "")
+                    .font(.callout)
+                    .padding(10)
+                    .lineLimit(5)
+            }
+        case .link:
+            if let path = item.link?.imageFile, let image = UIImage(contentsOfFile: path) {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.gray.opacity(0.15))
+                    .overlay(Image(systemName: "link").font(.title))
+            }
+        case .image:
+            if let path = item.image?.imageFile, let image = UIImage(contentsOfFile: path) {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.gray.opacity(0.15))
+            }
+        }
+    }
+}
+
+struct ItemContextMenu: View {
+    let item: Item
+
+    var body: some View {
+        Button("Move…", systemImage: "folder") {}
+        Button("Archive", systemImage: "archivebox") {}
+        Divider()
+        Button("Delete", systemImage: "trash", role: .destructive) {}
+    }
+}

--- a/BleepClone/UI/Screens/HomeView.swift
+++ b/BleepClone/UI/Screens/HomeView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import SwiftData
+
+struct HomeView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Room.createdAt) private var rooms: [Room]
+    @State private var selection: Segment = .everything
+
+    enum Segment: String, CaseIterable {
+        case everything
+        case bookmarks
+        case notes
+        case images
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Picker("", selection: $selection) {
+                    ForEach(Segment.allCases, id: \.self) { segment in
+                        Text(segment.rawValue.capitalized).tag(segment)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding()
+
+                ScrollView {
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                        ForEach(filteredItems()) { item in
+                            NavigationLink(value: item) {
+                                CardView(item: item)
+                            }
+                        }
+                    }
+                    .padding()
+                }
+                .navigationTitle(selection.rawValue.capitalized)
+                .navigationDestination(for: Item.self) { item in
+                    ItemDestination(item: item)
+                }
+
+                ActionBar(
+                    onNewNote: { createNote(in: nil) },
+                    onAddLink: { /* present link sheet */ },
+                    onAddImage: { /* present photos picker */ }
+                )
+                .padding()
+            }
+            .task {
+                RoomSeeder.seedIfNeeded(modelContext: modelContext)
+            }
+        }
+    }
+
+    private func filteredItems() -> [Item] {
+        let all = rooms.flatMap { $0.items }.filter { !$0.archived }
+        switch selection {
+        case .everything:
+            return all
+        case .bookmarks:
+            return all.filter { $0.kind == .link }
+        case .notes:
+            return all.filter { $0.kind == .note }
+        case .images:
+            return all.filter { $0.kind == .image }
+        }
+    }
+
+    private func createNote(in room: Room?) {
+        let item = Item(kind: .note, title: "", room: room)
+        item.note = .init(markdown: "")
+        modelContext.insert(item)
+    }
+}
+
+private struct ItemDestination: View {
+    let item: Item
+
+    var body: some View {
+        switch item.kind {
+        case .note:
+            NoteEditorView(item: item)
+        case .link:
+            LinkReaderView(item: item)
+        case .image:
+            ImageViewerView(item: item)
+        }
+    }
+}

--- a/BleepClone/UI/Screens/ImageViewerView.swift
+++ b/BleepClone/UI/Screens/ImageViewerView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct ImageViewerView: View {
+    let item: Item
+
+    var body: some View {
+        GeometryReader { proxy in
+            if let path = item.image?.imageFile, let image = UIImage(contentsOfFile: path) {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: proxy.size.width, height: proxy.size.height)
+                    .background(Color.black.opacity(0.95))
+            } else {
+                Text("Missing image")
+            }
+        }
+        .ignoresSafeArea()
+        .navigationTitle(item.image?.caption ?? "Image")
+    }
+}

--- a/BleepClone/UI/Screens/LinkReaderView.swift
+++ b/BleepClone/UI/Screens/LinkReaderView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import WebKit
+
+struct LinkReaderView: View {
+    let item: Item
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let link = item.link {
+                Header(link: link)
+            }
+            WebView(url: item.link?.url)
+        }
+        .navigationTitle(item.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    struct Header: View {
+        let link: LinkPayload
+
+        var body: some View {
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: "globe")
+                VStack(alignment: .leading) {
+                    Text(link.url.host() ?? "")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    if let summary = link.summary {
+                        Text(summary)
+                            .font(.footnote)
+                            .lineLimit(2)
+                    }
+                }
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .background(.thinMaterial)
+        }
+    }
+}
+
+struct WebView: UIViewRepresentable {
+    let url: URL?
+
+    func makeUIView(context: Context) -> WKWebView {
+        WKWebView()
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        if let url {
+            uiView.load(URLRequest(url: url))
+        }
+    }
+}

--- a/BleepClone/UI/Screens/NewRoomSheet.swift
+++ b/BleepClone/UI/Screens/NewRoomSheet.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import SwiftData
+
+struct NewRoomSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @State private var name = ""
+    @State private var icon: RoomIcon = .none
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Name", text: $name)
+                Picker("Icon", selection: Binding(
+                    get: {
+                        switch icon {
+                        case .none:
+                            return 0
+                        case .emoji:
+                            return 1
+                        case .imageFile:
+                            return 2
+                        }
+                    },
+                    set: { index in
+                        switch index {
+                        case 1:
+                            icon = .emoji("📁")
+                        case 2:
+                            icon = .imageFile("")
+                        default:
+                            icon = .none
+                        }
+                    }
+                )) {
+                    Text("None").tag(0)
+                    Text("Emoji").tag(1)
+                    Text("Image").tag(2)
+                }
+            }
+            .navigationTitle("New Room")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Save", action: save)
+                }
+            }
+        }
+    }
+
+    private func save() {
+        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+            return
+        }
+        let room = Room(name: name, icon: icon)
+        modelContext.insert(room)
+        dismiss()
+    }
+}

--- a/BleepClone/UI/Screens/NoteEditorView.swift
+++ b/BleepClone/UI/Screens/NoteEditorView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct NoteEditorView: View {
+    @Bindable var item: Item
+    @State private var text: String
+
+    init(item: Item) {
+        self.item = item
+        _text = State(initialValue: item.note?.markdown ?? "")
+    }
+
+    var body: some View {
+        TextEditor(text: $text)
+            .padding()
+            .navigationTitle(item.title.isEmpty ? "Note" : item.title)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Save") { save() }
+                }
+            }
+    }
+
+    private func save() {
+        item.title = title(from: text)
+        item.note = .init(markdown: text)
+        item.updatedAt = .now
+    }
+
+    private func title(from text: String) -> String {
+        let firstLine = text.split(separator: "\n").first ?? "Note"
+        return String(firstLine).trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/BleepClone/UI/Screens/RoomView.swift
+++ b/BleepClone/UI/Screens/RoomView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct RoomView: View {
+    @Bindable var room: Room
+    @State private var query = ""
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                ForEach(filteredItems()) { item in
+                    NavigationLink(value: item) {
+                        CardView(item: item)
+                    }
+                }
+            }
+            .padding()
+        }
+        .navigationTitle(room.name)
+        .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always))
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Button("Select Items", systemImage: "checkmark.circle") {}
+                    Button("Edit Room", systemImage: "pencil") {}
+                    Button("Add Sub-Room", systemImage: "folder.badge.plus") {}
+                    Button("Move…", systemImage: "folder") {}
+                    Button("Archive", systemImage: "archivebox") {}
+                } label: {
+                    Image(systemName: "ellipsis")
+                }
+            }
+        }
+    }
+
+    private func filteredItems() -> [Item] {
+        let base = room.items.filter { !$0.archived }
+        guard !query.isEmpty else {
+            return base
+        }
+        return base.filter { item in
+            item.title.localizedCaseInsensitiveContains(query)
+                || (item.subtitle ?? "").localizedCaseInsensitiveContains(query)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-keep
+# Omnilaze Keeper
+
+This repository contains a SwiftUI starter implementation for replicating the Bleep knowledge collector application on iOS. See `BleepClone/README.md` for details.


### PR DESCRIPTION
## Summary
- add SwiftData models, seeding helper, and entry point for the Bleep-style SwiftUI app
- implement reusable UI components and screens that mirror the referenced design, including cards, rooms, and detail views
- provide services for link previews and image persistence plus documentation for the starter structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d53746048c8327896b54a8e553a6c0